### PR TITLE
Fix use statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SYNOPSIS
 ========
 
 ```raku
-use Game::Covid::19;
+use Game::Covid19;
 
 play(age => 64);  # must specify age
 


### PR DESCRIPTION
The `use` statement contained a superfluous set of double colons which meant that copying and pasting the synopsis code didn't work (in e.g. the REPL). This change fixes the issue and allows new users to use the synopsis code as-is :-)